### PR TITLE
CI: fix buildroot build issue due to rename in patch

### DIFF
--- a/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/opt/gbridge.sh
+++ b/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/opt/gbridge.sh
@@ -20,4 +20,4 @@ sleep 1
 gbridge > /var/log/gbridge &
 
 sleep 5
-for i in `seq 1 100000`; do gpioset 0 6=1; gpioset 0 6=0; sleep 1; done &
+while true; do gpioset 0 6=1; gpioset 0 6=0; sleep 1; done &

--- a/sw/buildroot/patches/linux/0008-mikrobus-add-gbphy.h-and-mikrobus.h.patch
+++ b/sw/buildroot/patches/linux/0008-mikrobus-add-gbphy.h-and-mikrobus.h.patch
@@ -1,0 +1,1 @@
+../../../linux/0008-mikrobus-add-gbphy.h-and-mikrobus.h.patch

--- a/sw/linux/0007-mikrobus-mikrobus-over-greybus.patch
+++ b/sw/linux/0007-mikrobus-mikrobus-over-greybus.patch
@@ -1,4 +1,4 @@
-From 07a5216eb39a3fe8b0823461834239425fc34566 Mon Sep 17 00:00:00 2001
+From 3d6cc782ffe2e05f6c8384f3bebe379b9139ae01 Mon Sep 17 00:00:00 2001
 From: Vaishnav M A <vaishnav@beagleboard.org>
 Date: Tue, 12 Jan 2021 06:27:16 +0530
 Subject: [PATCH] mikrobus: mikrobus over greybus
@@ -91,27 +91,27 @@ dev  in_humidityrelative_input  in_humidityrelative_oversampling_ratio  in_press
 
 Signed-off-by: Vaishnav M A <vaishnav@beagleboard.org>
 ---
- drivers/greybus/manifest.c                    | 18 ++++
- drivers/misc/mikrobus/mikrobus_core.c         | 90 ++++++++++++++++++-
- drivers/misc/mikrobus/mikrobus_id.c           |  4 +-
- drivers/misc/mikrobus/mikrobus_manifest.c     |  2 +-
- drivers/misc/mikrobus/mikrobus_manifest.h     |  2 +-
- drivers/staging/greybus/gbphy.c               | 10 +--
- drivers/staging/greybus/gpio.c                | 26 +-----
- drivers/staging/greybus/i2c.c                 | 11 +--
- drivers/staging/greybus/pwm.c                 |  2 +-
- drivers/staging/greybus/sdio.c                |  2 +-
- drivers/staging/greybus/spi.c                 |  2 +-
- drivers/staging/greybus/spilib.c              | 19 +---
- drivers/staging/greybus/uart.c                |  2 +-
- drivers/staging/greybus/usb.c                 |  2 +-
- include/linux/greybus/bundle.h                |  2 +
- .../staging => include/linux}/greybus/gbphy.h | 57 ++++++++++++
- include/linux/greybus/interface.h             |  2 +
- .../linux/mikrobus.h                          |  5 ++
- 18 files changed, 188 insertions(+), 70 deletions(-)
- rename {drivers/staging => include/linux}/greybus/gbphy.h (70%)
- rename drivers/misc/mikrobus/mikrobus_core.h => include/linux/mikrobus.h (97%)
+ drivers/greybus/manifest.c                |  18 ++
+ drivers/misc/mikrobus/mikrobus_core.c     |  90 +++++++++-
+ drivers/misc/mikrobus/mikrobus_core.h     | 202 ----------------------
+ drivers/misc/mikrobus/mikrobus_id.c       |   4 +-
+ drivers/misc/mikrobus/mikrobus_manifest.c |   2 +-
+ drivers/misc/mikrobus/mikrobus_manifest.h |   2 +-
+ drivers/staging/greybus/gbphy.c           |  10 +-
+ drivers/staging/greybus/gbphy.h           | 109 ------------
+ drivers/staging/greybus/gpio.c            |  26 +--
+ drivers/staging/greybus/i2c.c             |  11 +-
+ drivers/staging/greybus/pwm.c             |   2 +-
+ drivers/staging/greybus/sdio.c            |   2 +-
+ drivers/staging/greybus/spi.c             |   2 +-
+ drivers/staging/greybus/spilib.c          |  19 +-
+ drivers/staging/greybus/uart.c            |   2 +-
+ drivers/staging/greybus/usb.c             |   2 +-
+ include/linux/greybus/bundle.h            |   2 +
+ include/linux/greybus/interface.h         |   2 +
+ 18 files changed, 126 insertions(+), 381 deletions(-)
+ delete mode 100644 drivers/misc/mikrobus/mikrobus_core.h
+ delete mode 100644 drivers/staging/greybus/gbphy.h
 
 diff --git a/drivers/greybus/manifest.c b/drivers/greybus/manifest.c
 index dd7040697bde..9be09511b4df 100644
@@ -281,6 +281,214 @@ index bbf8f541d19a..f69176fc5d4e 100644
  static int mikrobus_port_probe_pinctrl_setup(struct mikrobus_port *port)
  {
  	struct pinctrl_state *state;
+diff --git a/drivers/misc/mikrobus/mikrobus_core.h b/drivers/misc/mikrobus/mikrobus_core.h
+deleted file mode 100644
+index ef7ddce660cb..000000000000
+--- a/drivers/misc/mikrobus/mikrobus_core.h
++++ /dev/null
+@@ -1,202 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * mikroBUS Driver for instantiating add-on
+- * board devices with an identifier EEPROM
+- *
+- * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
+- */
+-
+-#ifndef __MIKROBUS_H
+-#define __MIKROBUS_H
+-
+-#include <linux/kernel.h>
+-#include <linux/device.h>
+-#include <linux/i2c.h>
+-#include <linux/gpio.h>
+-#include <linux/gpio/consumer.h>
+-#include <linux/gpio/machine.h>
+-#include <linux/spi/spi.h>
+-#include <linux/serdev.h>
+-#include <linux/property.h>
+-#include <linux/pinctrl/pinctrl.h>
+-#include <linux/pinctrl/pinmux.h>
+-#include <linux/pinctrl/consumer.h>
+-#include <linux/nvmem-consumer.h>
+-#include <linux/nvmem-provider.h>
+-
+-#define MIKROBUS_VERSION_MAJOR 0x00
+-#define MIKROBUS_VERSION_MINOR 0x03
+-
+-#define MIKROBUS_NAME_SIZE		40
+-#define MIKROBUS_PINCTRL_NAME_SIZE	20
+-
+-#define MIKROBUS_NUM_PINCTRL_STATE	4
+-#define MIKROBUS_NUM_CS			2
+-
+-#define MIKROBUS_PINCTRL_PWM		0
+-#define MIKROBUS_PINCTRL_UART		1
+-#define MIKROBUS_PINCTRL_I2C		2
+-#define MIKROBUS_PINCTRL_SPI		3
+-
+-#define MIKROBUS_PINCTRL_STATE_GPIO	"gpio"
+-
+-#define MIKROBUS_EEPROM_EXIT_ID_CMD 0xD2
+-
+-extern struct bus_type mikrobus_bus_type;
+-extern struct device_type mikrobus_port_type;
+-extern const char *MIKROBUS_PINCTRL_STR[];
+-
+-enum mikrobus_property_type {
+-	MIKROBUS_PROPERTY_TYPE_MIKROBUS = 0x00,
+-	MIKROBUS_PROPERTY_TYPE_PROPERTY	= 0x01,
+-	MIKROBUS_PROPERTY_TYPE_GPIO	= 0x02,
+-	MIKROBUS_PROPERTY_TYPE_U8	= 0x03,
+-	MIKROBUS_PROPERTY_TYPE_U16	= 0x04,
+-	MIKROBUS_PROPERTY_TYPE_U32	= 0x05,
+-	MIKROBUS_PROPERTY_TYPE_U64	= 0x06,
+-	MIKROBUS_PROPERTY_TYPE_REGULATOR	= 0x07,
+-	MIKROBUS_PROPERTY_TYPE_CLOCK	= 0x08,
+-};
+-
+-enum mikrobus_pin {
+-	MIKROBUS_PIN_PWM	= 0x00,
+-	MIKROBUS_PIN_INT	= 0x01,
+-	MIKROBUS_PIN_RX		= 0x02,
+-	MIKROBUS_PIN_TX		= 0x03,
+-	MIKROBUS_PIN_SCL	= 0x04,
+-	MIKROBUS_PIN_SDA	= 0x05,
+-	MIKROBUS_PIN_MOSI	= 0x06,
+-	MIKROBUS_PIN_MISO	= 0x07,
+-	MIKROBUS_PIN_SCK	= 0x08,
+-	MIKROBUS_PIN_CS		= 0x09,
+-	MIKROBUS_PIN_RST	= 0x0A,
+-	MIKROBUS_PIN_AN		= 0x0B,
+-	MIKROBUS_PORT_PIN_COUNT = 0x0C,
+-};
+-
+-enum mikrobus_pin_state {
+-	MIKROBUS_STATE_INPUT		= 0x01,
+-	MIKROBUS_STATE_OUTPUT_HIGH	= 0x02,
+-	MIKROBUS_STATE_OUTPUT_LOW	= 0x03,
+-	MIKROBUS_STATE_PWM		= 0x04,
+-	MIKROBUS_STATE_SPI		= 0x05,
+-	MIKROBUS_STATE_I2C		= 0x06,
+-	MIKROBUS_STATE_UART		= 0x07,
+-};
+-
+-/*
+- * board_device_info describes a single device on a mikrobus add-on
+- * board, an add-on board can present one or more device to the host
+- *
+- * @gpio_lookup: used to provide the GPIO lookup table for
+- * passing the named GPIOs to device drivers.
+- * @properties: used to provide the property_entry to pass named
+- * properties to device drivers, applicable only when driver uses
+- * device_property_read_* calls to fetch the properties.
+- * @num_gpio_resources: number of named gpio resources for the device,
+- * used mainly for gpiod_lookup_table memory allocation.
+- * @num_properties: number of custom properties for the device,
+- * used mainly for property_entry memory allocation.
+- * @protocol: used to know the type of the device and it should
+- * contain one of the values defined under 'enum greybus_class_type'
+- * under linux/greybus/greybus_manifest.h
+- * @reg: I2C address for the device, for devices on the SPI bus
+- * this field is the chip select address relative to the mikrobus
+- * port:0->device chip select connected to CS pin on mikroBUS port
+- *	1->device chip select connected to RST Pin on mikroBUS port
+- * @mode: SPI mode
+- * @max_speed_hz: SPI max speed(Hz)
+- * @drv_name: device_id to match with the driver
+- * @irq_type: type of IRQ trigger , match with defines in linux/interrupt.h
+- * @irq: irq number relative to the mikrobus port should contain one of the
+- * values defined under 'enum mikrobus_pin'
+- * @id: device id starting from 1
+- */
+-struct board_device_info {
+-	struct gpiod_lookup_table *gpio_lookup;
+-	struct property_entry *properties;
+-	struct property_entry *regulators;
+-	struct property_entry *clocks;
+-	struct list_head links;
+-	unsigned short num_gpio_resources;
+-	unsigned short num_properties;
+-	unsigned short num_regulators;
+-	unsigned short num_clocks;
+-	unsigned short protocol;
+-	unsigned short reg;
+-	unsigned int mode;
+-	void *dev_client;
+-	u32 max_speed_hz;
+-	char *drv_name;
+-	int irq_type;
+-	int irq;
+-	int id;
+-};
+-
+-/*
+- * addon_board_info describes a mikrobus add-on device the add-on
+- * board, an add-on board can present one or more device to the host
+- *
+- * @manifest_descs: list of manifest descriptors
+- * @devices: list of devices on the board
+- * @pin_state: the state of each pin on the mikrobus port required
+- * for the add-on board should contain one of the values defined under
+- * 'enum mikrobus_pin_state' restrictions are as per mikrobus standard
+- * specifications.
+- * @name: add-on board name
+- */
+-struct addon_board_info {
+-	struct list_head manifest_descs;
+-	struct list_head devices;
+-	u8 pin_state[MIKROBUS_PORT_PIN_COUNT];
+-	char *name;
+-};
+-
+-/*
+- * mikrobus_port describes the peripherals mapped to a
+- * mikrobus port.
+- *
+- * @eeprom_client: i2c_client corresponding to the eeprom
+- * on the add-on board.
+- * @board: pointer to the attached add-on board.
+- * @i2c_adap: I2C adapter attached to the mikrobus port.
+- * @spi_mstr: SPI master attached to the mikrobus port.
+- * @eeprom: nvmem_device for the eeprom on the add-on board.
+- * @pwm: pwm_device attached to the mikrobus port PWM pin.
+- * @pinctrl_selected: current pinctrl_selected state.
+- * @chip_select: chip select number mapped to the SPI
+- * CS pin on the mikrobus port and the RST pin on the mikrobus
+- * port
+- * @id: port id starting from 1
+- */
+-struct mikrobus_port {
+-	struct addon_board_info *board;
+-	struct nvmem_device *eeprom;
+-	struct i2c_adapter *i2c_adap;
+-	struct spi_master *spi_mstr;
+-	struct w1_master *w1_master;
+-	struct platform_device *w1_gpio;
+-	struct serdev_controller *ser_ctrl;
+-	struct gpio_descs *gpios;
+-	struct pwm_device *pwm;
+-	struct pinctrl *pinctrl;
+-	struct module *owner;
+-	struct device dev;
+-	char name[MIKROBUS_NAME_SIZE];
+-	char *pinctrl_selected[MIKROBUS_NUM_PINCTRL_STATE];
+-	unsigned int chip_select[MIKROBUS_NUM_CS];
+-	int skip_scan;
+-	int id;
+-};
+-#define to_mikrobus_port(d) container_of(d, struct mikrobus_port, dev)
+-
+-void mikrobus_board_unregister(struct mikrobus_port *port,
+-				struct addon_board_info *board);
+-int mikrobus_board_register(struct mikrobus_port *port,
+-				struct addon_board_info *board);
+-int mikrobus_port_register(struct mikrobus_port *port);
+-int mikrobus_port_pinctrl_select(struct mikrobus_port *port);
+-void mikrobus_port_delete(struct mikrobus_port *port);
+-int mikrobus_port_scan_eeprom(struct mikrobus_port *port);
+-struct mikrobus_port *mikrobus_find_port_by_w1_master(struct w1_master *master);
+-#endif /* __MIKROBUS_H */
 diff --git a/drivers/misc/mikrobus/mikrobus_id.c b/drivers/misc/mikrobus/mikrobus_id.c
 index e891645f745c..183de02cd74f 100644
 --- a/drivers/misc/mikrobus/mikrobus_id.c
@@ -359,6 +567,121 @@ index 9fc5c47be9bd..0d5004f12ff9 100644
  	gb_pm_runtime_put_autosuspend(bundle);
  
  	return 0;
+diff --git a/drivers/staging/greybus/gbphy.h b/drivers/staging/greybus/gbphy.h
+deleted file mode 100644
+index 087928a586fb..000000000000
+--- a/drivers/staging/greybus/gbphy.h
++++ /dev/null
+@@ -1,109 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * Greybus Bridged-Phy Bus driver
+- *
+- * Copyright 2016 Google Inc.
+- */
+-
+-#ifndef __GBPHY_H
+-#define __GBPHY_H
+-
+-struct gbphy_device {
+-	u32 id;
+-	struct greybus_descriptor_cport *cport_desc;
+-	struct gb_bundle *bundle;
+-	struct list_head list;
+-	struct device dev;
+-};
+-#define to_gbphy_dev(d) container_of(d, struct gbphy_device, dev)
+-
+-static inline void *gb_gbphy_get_data(struct gbphy_device *gdev)
+-{
+-	return dev_get_drvdata(&gdev->dev);
+-}
+-
+-static inline void gb_gbphy_set_data(struct gbphy_device *gdev, void *data)
+-{
+-	dev_set_drvdata(&gdev->dev, data);
+-}
+-
+-struct gbphy_device_id {
+-	__u8 protocol_id;
+-};
+-
+-#define GBPHY_PROTOCOL(p)		\
+-	.protocol_id	= (p),
+-
+-struct gbphy_driver {
+-	const char *name;
+-	int (*probe)(struct gbphy_device *,
+-		     const struct gbphy_device_id *id);
+-	void (*remove)(struct gbphy_device *);
+-	const struct gbphy_device_id *id_table;
+-
+-	struct device_driver driver;
+-};
+-#define to_gbphy_driver(d) container_of(d, struct gbphy_driver, driver)
+-
+-int gb_gbphy_register_driver(struct gbphy_driver *driver,
+-			     struct module *owner, const char *mod_name);
+-void gb_gbphy_deregister_driver(struct gbphy_driver *driver);
+-
+-#define gb_gbphy_register(driver) \
+-	gb_gbphy_register_driver(driver, THIS_MODULE, KBUILD_MODNAME)
+-#define gb_gbphy_deregister(driver) \
+-	gb_gbphy_deregister_driver(driver)
+-
+-/**
+- * module_gbphy_driver() - Helper macro for registering a gbphy driver
+- * @__gbphy_driver: gbphy_driver structure
+- *
+- * Helper macro for gbphy drivers to set up proper module init / exit
+- * functions.  Replaces module_init() and module_exit() and keeps people from
+- * printing pointless things to the kernel log when their driver is loaded.
+- */
+-#define module_gbphy_driver(__gbphy_driver)	\
+-	module_driver(__gbphy_driver, gb_gbphy_register, gb_gbphy_deregister)
+-
+-#ifdef CONFIG_PM
+-static inline int gbphy_runtime_get_sync(struct gbphy_device *gbphy_dev)
+-{
+-	struct device *dev = &gbphy_dev->dev;
+-	int ret;
+-
+-	ret = pm_runtime_get_sync(dev);
+-	if (ret < 0) {
+-		dev_err(dev, "pm_runtime_get_sync failed: %d\n", ret);
+-		pm_runtime_put_noidle(dev);
+-		return ret;
+-	}
+-
+-	return 0;
+-}
+-
+-static inline void gbphy_runtime_put_autosuspend(struct gbphy_device *gbphy_dev)
+-{
+-	struct device *dev = &gbphy_dev->dev;
+-
+-	pm_runtime_mark_last_busy(dev);
+-	pm_runtime_put_autosuspend(dev);
+-}
+-
+-static inline void gbphy_runtime_get_noresume(struct gbphy_device *gbphy_dev)
+-{
+-	pm_runtime_get_noresume(&gbphy_dev->dev);
+-}
+-
+-static inline void gbphy_runtime_put_noidle(struct gbphy_device *gbphy_dev)
+-{
+-	pm_runtime_put_noidle(&gbphy_dev->dev);
+-}
+-#else
+-static inline int gbphy_runtime_get_sync(struct gbphy_device *gbphy_dev) { return 0; }
+-static inline void gbphy_runtime_put_autosuspend(struct gbphy_device *gbphy_dev) {}
+-static inline void gbphy_runtime_get_noresume(struct gbphy_device *gbphy_dev) {}
+-static inline void gbphy_runtime_put_noidle(struct gbphy_device *gbphy_dev) {}
+-#endif
+-
+-#endif /* __GBPHY_H */
+-
 diff --git a/drivers/staging/greybus/gpio.c b/drivers/staging/greybus/gpio.c
 index 36d99f9e419e..ce3ad6690fe7 100644
 --- a/drivers/staging/greybus/gpio.c
@@ -527,74 +850,6 @@ index df8d88424cb7..f54ceecf2be8 100644
  };
  #define to_gb_bundle(d) container_of(d, struct gb_bundle, dev)
  
-diff --git a/drivers/staging/greybus/gbphy.h b/drivers/staging/greybus/gbphy.h
-index 087928a586fb..cfc23589b2e2 100644
---- a/drivers/staging/greybus/gbphy.h
-+++ b/drivers/staging/greybus/gbphy.h
-@@ -8,6 +8,63 @@
- #ifndef __GBPHY_H
- #define __GBPHY_H
- 
-+#include <linux/i2c.h>
-+#include <linux/gpio/driver.h>
-+
-+struct gbphy_host {
-+	struct gb_bundle *bundle;
-+	struct list_head devices;
-+};
-+
-+
-+struct gb_i2c_device {
-+	struct gb_connection	*connection;
-+	struct gbphy_device	*gbphy_dev;
-+	u32			functionality;
-+	struct i2c_adapter	adapter;
-+};
-+
-+struct gb_spilib {
-+	struct gb_connection	*connection;
-+	struct device		*parent;
-+	struct spi_transfer	*first_xfer;
-+	struct spi_transfer	*last_xfer;
-+	struct spilib_ops	*ops;
-+	u32			rx_xfer_offset;
-+	u32			tx_xfer_offset;
-+	u32			last_xfer_size;
-+	unsigned int		op_timeout;
-+	u16			mode;
-+	u16			flags;
-+	u32			bits_per_word_mask;
-+	u8			num_chipselect;
-+	u32			min_speed_hz;
-+	u32			max_speed_hz;
-+};
-+struct gb_gpio_line {
-+	/* The following has to be an array of line_max entries */
-+	/* --> make them just a flags field */
-+	u8			active:    1,
-+				direction: 1,	/* 0 = output, 1 = input */
-+				value:     1;	/* 0 = low, 1 = high */
-+	u16			debounce_usec;
-+
-+	u8			irq_type;
-+	bool			irq_type_pending;
-+	bool			masked;
-+	bool			masked_pending;
-+};
-+
-+struct gb_gpio_controller {
-+	struct gbphy_device	*gbphy_dev;
-+	struct gb_connection	*connection;
-+	u8			line_max;	/* max line number */
-+	struct gb_gpio_line	*lines;
-+	struct gpio_chip	chip;
-+	struct irq_chip		irqc;
-+	struct mutex		irq_lock;
-+};
-+
- struct gbphy_device {
- 	u32 id;
- 	struct greybus_descriptor_cport *cport_desc;
 diff --git a/include/linux/greybus/interface.h b/include/linux/greybus/interface.h
 index ce4def881e6f..a7d8d40fa300 100644
 --- a/include/linux/greybus/interface.h
@@ -608,41 +863,6 @@ index ce4def881e6f..a7d8d40fa300 100644
  };
  #define to_gb_interface(d) container_of(d, struct gb_interface, dev)
  
-diff --git a/drivers/misc/mikrobus/mikrobus_core.h b/drivers/misc/mikrobus/mikrobus_core.h
-index ef7ddce660cb..4999ac70e566 100644
---- a/drivers/misc/mikrobus/mikrobus_core.h
-+++ b/drivers/misc/mikrobus/mikrobus_core.h
-@@ -18,11 +18,13 @@
- #include <linux/spi/spi.h>
- #include <linux/serdev.h>
- #include <linux/property.h>
-+#include <linux/greybus.h>
- #include <linux/pinctrl/pinctrl.h>
- #include <linux/pinctrl/pinmux.h>
- #include <linux/pinctrl/consumer.h>
- #include <linux/nvmem-consumer.h>
- #include <linux/nvmem-provider.h>
-+#include <linux/greybus/gbphy.h>
- 
- #define MIKROBUS_VERSION_MAJOR 0x00
- #define MIKROBUS_VERSION_MINOR 0x03
-@@ -186,6 +188,7 @@ struct mikrobus_port {
- 	char *pinctrl_selected[MIKROBUS_NUM_PINCTRL_STATE];
- 	unsigned int chip_select[MIKROBUS_NUM_CS];
- 	int skip_scan;
-+	int disable_eeprom;
- 	int id;
- };
- #define to_mikrobus_port(d) container_of(d, struct mikrobus_port, dev)
-@@ -194,6 +197,8 @@ void mikrobus_board_unregister(struct mikrobus_port *port,
- 				struct addon_board_info *board);
- int mikrobus_board_register(struct mikrobus_port *port,
- 				struct addon_board_info *board);
-+
-+int mikrobus_port_gb_register(struct gbphy_host *host, void *manifest_blob, size_t manifest_size);
- int mikrobus_port_register(struct mikrobus_port *port);
- int mikrobus_port_pinctrl_select(struct mikrobus_port *port);
- void mikrobus_port_delete(struct mikrobus_port *port);
 -- 
 2.30.0
 

--- a/sw/linux/0008-mikrobus-add-gbphy.h-and-mikrobus.h.patch
+++ b/sw/linux/0008-mikrobus-add-gbphy.h-and-mikrobus.h.patch
@@ -1,0 +1,404 @@
+From fe6266f94006a417f294275116ed7fb7f9f5fdd7 Mon Sep 17 00:00:00 2001
+From: Vaishnav M A <vaishnav@beagleboard.org>
+Date: Mon, 18 Jan 2021 12:19:27 +0530
+Subject: [PATCH] mikrobus: add gbphy.h and mikrobus.h
+
+split the rename changes across two separate patches
+to work around the buildroot apply-patch issue.
+
+Signed-off-by: Vaishnav M A <vaishnav@beagleboard.org>
+---
+ include/linux/greybus/gbphy.h | 166 +++++++++++++++++++++++++++
+ include/linux/mikrobus.h      | 207 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 373 insertions(+)
+ create mode 100644 include/linux/greybus/gbphy.h
+ create mode 100644 include/linux/mikrobus.h
+
+diff --git a/include/linux/greybus/gbphy.h b/include/linux/greybus/gbphy.h
+new file mode 100644
+index 000000000000..cfc23589b2e2
+--- /dev/null
++++ b/include/linux/greybus/gbphy.h
+@@ -0,0 +1,166 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Greybus Bridged-Phy Bus driver
++ *
++ * Copyright 2016 Google Inc.
++ */
++
++#ifndef __GBPHY_H
++#define __GBPHY_H
++
++#include <linux/i2c.h>
++#include <linux/gpio/driver.h>
++
++struct gbphy_host {
++	struct gb_bundle *bundle;
++	struct list_head devices;
++};
++
++
++struct gb_i2c_device {
++	struct gb_connection	*connection;
++	struct gbphy_device	*gbphy_dev;
++	u32			functionality;
++	struct i2c_adapter	adapter;
++};
++
++struct gb_spilib {
++	struct gb_connection	*connection;
++	struct device		*parent;
++	struct spi_transfer	*first_xfer;
++	struct spi_transfer	*last_xfer;
++	struct spilib_ops	*ops;
++	u32			rx_xfer_offset;
++	u32			tx_xfer_offset;
++	u32			last_xfer_size;
++	unsigned int		op_timeout;
++	u16			mode;
++	u16			flags;
++	u32			bits_per_word_mask;
++	u8			num_chipselect;
++	u32			min_speed_hz;
++	u32			max_speed_hz;
++};
++struct gb_gpio_line {
++	/* The following has to be an array of line_max entries */
++	/* --> make them just a flags field */
++	u8			active:    1,
++				direction: 1,	/* 0 = output, 1 = input */
++				value:     1;	/* 0 = low, 1 = high */
++	u16			debounce_usec;
++
++	u8			irq_type;
++	bool			irq_type_pending;
++	bool			masked;
++	bool			masked_pending;
++};
++
++struct gb_gpio_controller {
++	struct gbphy_device	*gbphy_dev;
++	struct gb_connection	*connection;
++	u8			line_max;	/* max line number */
++	struct gb_gpio_line	*lines;
++	struct gpio_chip	chip;
++	struct irq_chip		irqc;
++	struct mutex		irq_lock;
++};
++
++struct gbphy_device {
++	u32 id;
++	struct greybus_descriptor_cport *cport_desc;
++	struct gb_bundle *bundle;
++	struct list_head list;
++	struct device dev;
++};
++#define to_gbphy_dev(d) container_of(d, struct gbphy_device, dev)
++
++static inline void *gb_gbphy_get_data(struct gbphy_device *gdev)
++{
++	return dev_get_drvdata(&gdev->dev);
++}
++
++static inline void gb_gbphy_set_data(struct gbphy_device *gdev, void *data)
++{
++	dev_set_drvdata(&gdev->dev, data);
++}
++
++struct gbphy_device_id {
++	__u8 protocol_id;
++};
++
++#define GBPHY_PROTOCOL(p)		\
++	.protocol_id	= (p),
++
++struct gbphy_driver {
++	const char *name;
++	int (*probe)(struct gbphy_device *,
++		     const struct gbphy_device_id *id);
++	void (*remove)(struct gbphy_device *);
++	const struct gbphy_device_id *id_table;
++
++	struct device_driver driver;
++};
++#define to_gbphy_driver(d) container_of(d, struct gbphy_driver, driver)
++
++int gb_gbphy_register_driver(struct gbphy_driver *driver,
++			     struct module *owner, const char *mod_name);
++void gb_gbphy_deregister_driver(struct gbphy_driver *driver);
++
++#define gb_gbphy_register(driver) \
++	gb_gbphy_register_driver(driver, THIS_MODULE, KBUILD_MODNAME)
++#define gb_gbphy_deregister(driver) \
++	gb_gbphy_deregister_driver(driver)
++
++/**
++ * module_gbphy_driver() - Helper macro for registering a gbphy driver
++ * @__gbphy_driver: gbphy_driver structure
++ *
++ * Helper macro for gbphy drivers to set up proper module init / exit
++ * functions.  Replaces module_init() and module_exit() and keeps people from
++ * printing pointless things to the kernel log when their driver is loaded.
++ */
++#define module_gbphy_driver(__gbphy_driver)	\
++	module_driver(__gbphy_driver, gb_gbphy_register, gb_gbphy_deregister)
++
++#ifdef CONFIG_PM
++static inline int gbphy_runtime_get_sync(struct gbphy_device *gbphy_dev)
++{
++	struct device *dev = &gbphy_dev->dev;
++	int ret;
++
++	ret = pm_runtime_get_sync(dev);
++	if (ret < 0) {
++		dev_err(dev, "pm_runtime_get_sync failed: %d\n", ret);
++		pm_runtime_put_noidle(dev);
++		return ret;
++	}
++
++	return 0;
++}
++
++static inline void gbphy_runtime_put_autosuspend(struct gbphy_device *gbphy_dev)
++{
++	struct device *dev = &gbphy_dev->dev;
++
++	pm_runtime_mark_last_busy(dev);
++	pm_runtime_put_autosuspend(dev);
++}
++
++static inline void gbphy_runtime_get_noresume(struct gbphy_device *gbphy_dev)
++{
++	pm_runtime_get_noresume(&gbphy_dev->dev);
++}
++
++static inline void gbphy_runtime_put_noidle(struct gbphy_device *gbphy_dev)
++{
++	pm_runtime_put_noidle(&gbphy_dev->dev);
++}
++#else
++static inline int gbphy_runtime_get_sync(struct gbphy_device *gbphy_dev) { return 0; }
++static inline void gbphy_runtime_put_autosuspend(struct gbphy_device *gbphy_dev) {}
++static inline void gbphy_runtime_get_noresume(struct gbphy_device *gbphy_dev) {}
++static inline void gbphy_runtime_put_noidle(struct gbphy_device *gbphy_dev) {}
++#endif
++
++#endif /* __GBPHY_H */
++
+diff --git a/include/linux/mikrobus.h b/include/linux/mikrobus.h
+new file mode 100644
+index 000000000000..4999ac70e566
+--- /dev/null
++++ b/include/linux/mikrobus.h
+@@ -0,0 +1,207 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mikroBUS Driver for instantiating add-on
++ * board devices with an identifier EEPROM
++ *
++ * Copyright 2020 Vaishnav M A, BeagleBoard.org Foundation.
++ */
++
++#ifndef __MIKROBUS_H
++#define __MIKROBUS_H
++
++#include <linux/kernel.h>
++#include <linux/device.h>
++#include <linux/i2c.h>
++#include <linux/gpio.h>
++#include <linux/gpio/consumer.h>
++#include <linux/gpio/machine.h>
++#include <linux/spi/spi.h>
++#include <linux/serdev.h>
++#include <linux/property.h>
++#include <linux/greybus.h>
++#include <linux/pinctrl/pinctrl.h>
++#include <linux/pinctrl/pinmux.h>
++#include <linux/pinctrl/consumer.h>
++#include <linux/nvmem-consumer.h>
++#include <linux/nvmem-provider.h>
++#include <linux/greybus/gbphy.h>
++
++#define MIKROBUS_VERSION_MAJOR 0x00
++#define MIKROBUS_VERSION_MINOR 0x03
++
++#define MIKROBUS_NAME_SIZE		40
++#define MIKROBUS_PINCTRL_NAME_SIZE	20
++
++#define MIKROBUS_NUM_PINCTRL_STATE	4
++#define MIKROBUS_NUM_CS			2
++
++#define MIKROBUS_PINCTRL_PWM		0
++#define MIKROBUS_PINCTRL_UART		1
++#define MIKROBUS_PINCTRL_I2C		2
++#define MIKROBUS_PINCTRL_SPI		3
++
++#define MIKROBUS_PINCTRL_STATE_GPIO	"gpio"
++
++#define MIKROBUS_EEPROM_EXIT_ID_CMD 0xD2
++
++extern struct bus_type mikrobus_bus_type;
++extern struct device_type mikrobus_port_type;
++extern const char *MIKROBUS_PINCTRL_STR[];
++
++enum mikrobus_property_type {
++	MIKROBUS_PROPERTY_TYPE_MIKROBUS = 0x00,
++	MIKROBUS_PROPERTY_TYPE_PROPERTY	= 0x01,
++	MIKROBUS_PROPERTY_TYPE_GPIO	= 0x02,
++	MIKROBUS_PROPERTY_TYPE_U8	= 0x03,
++	MIKROBUS_PROPERTY_TYPE_U16	= 0x04,
++	MIKROBUS_PROPERTY_TYPE_U32	= 0x05,
++	MIKROBUS_PROPERTY_TYPE_U64	= 0x06,
++	MIKROBUS_PROPERTY_TYPE_REGULATOR	= 0x07,
++	MIKROBUS_PROPERTY_TYPE_CLOCK	= 0x08,
++};
++
++enum mikrobus_pin {
++	MIKROBUS_PIN_PWM	= 0x00,
++	MIKROBUS_PIN_INT	= 0x01,
++	MIKROBUS_PIN_RX		= 0x02,
++	MIKROBUS_PIN_TX		= 0x03,
++	MIKROBUS_PIN_SCL	= 0x04,
++	MIKROBUS_PIN_SDA	= 0x05,
++	MIKROBUS_PIN_MOSI	= 0x06,
++	MIKROBUS_PIN_MISO	= 0x07,
++	MIKROBUS_PIN_SCK	= 0x08,
++	MIKROBUS_PIN_CS		= 0x09,
++	MIKROBUS_PIN_RST	= 0x0A,
++	MIKROBUS_PIN_AN		= 0x0B,
++	MIKROBUS_PORT_PIN_COUNT = 0x0C,
++};
++
++enum mikrobus_pin_state {
++	MIKROBUS_STATE_INPUT		= 0x01,
++	MIKROBUS_STATE_OUTPUT_HIGH	= 0x02,
++	MIKROBUS_STATE_OUTPUT_LOW	= 0x03,
++	MIKROBUS_STATE_PWM		= 0x04,
++	MIKROBUS_STATE_SPI		= 0x05,
++	MIKROBUS_STATE_I2C		= 0x06,
++	MIKROBUS_STATE_UART		= 0x07,
++};
++
++/*
++ * board_device_info describes a single device on a mikrobus add-on
++ * board, an add-on board can present one or more device to the host
++ *
++ * @gpio_lookup: used to provide the GPIO lookup table for
++ * passing the named GPIOs to device drivers.
++ * @properties: used to provide the property_entry to pass named
++ * properties to device drivers, applicable only when driver uses
++ * device_property_read_* calls to fetch the properties.
++ * @num_gpio_resources: number of named gpio resources for the device,
++ * used mainly for gpiod_lookup_table memory allocation.
++ * @num_properties: number of custom properties for the device,
++ * used mainly for property_entry memory allocation.
++ * @protocol: used to know the type of the device and it should
++ * contain one of the values defined under 'enum greybus_class_type'
++ * under linux/greybus/greybus_manifest.h
++ * @reg: I2C address for the device, for devices on the SPI bus
++ * this field is the chip select address relative to the mikrobus
++ * port:0->device chip select connected to CS pin on mikroBUS port
++ *	1->device chip select connected to RST Pin on mikroBUS port
++ * @mode: SPI mode
++ * @max_speed_hz: SPI max speed(Hz)
++ * @drv_name: device_id to match with the driver
++ * @irq_type: type of IRQ trigger , match with defines in linux/interrupt.h
++ * @irq: irq number relative to the mikrobus port should contain one of the
++ * values defined under 'enum mikrobus_pin'
++ * @id: device id starting from 1
++ */
++struct board_device_info {
++	struct gpiod_lookup_table *gpio_lookup;
++	struct property_entry *properties;
++	struct property_entry *regulators;
++	struct property_entry *clocks;
++	struct list_head links;
++	unsigned short num_gpio_resources;
++	unsigned short num_properties;
++	unsigned short num_regulators;
++	unsigned short num_clocks;
++	unsigned short protocol;
++	unsigned short reg;
++	unsigned int mode;
++	void *dev_client;
++	u32 max_speed_hz;
++	char *drv_name;
++	int irq_type;
++	int irq;
++	int id;
++};
++
++/*
++ * addon_board_info describes a mikrobus add-on device the add-on
++ * board, an add-on board can present one or more device to the host
++ *
++ * @manifest_descs: list of manifest descriptors
++ * @devices: list of devices on the board
++ * @pin_state: the state of each pin on the mikrobus port required
++ * for the add-on board should contain one of the values defined under
++ * 'enum mikrobus_pin_state' restrictions are as per mikrobus standard
++ * specifications.
++ * @name: add-on board name
++ */
++struct addon_board_info {
++	struct list_head manifest_descs;
++	struct list_head devices;
++	u8 pin_state[MIKROBUS_PORT_PIN_COUNT];
++	char *name;
++};
++
++/*
++ * mikrobus_port describes the peripherals mapped to a
++ * mikrobus port.
++ *
++ * @eeprom_client: i2c_client corresponding to the eeprom
++ * on the add-on board.
++ * @board: pointer to the attached add-on board.
++ * @i2c_adap: I2C adapter attached to the mikrobus port.
++ * @spi_mstr: SPI master attached to the mikrobus port.
++ * @eeprom: nvmem_device for the eeprom on the add-on board.
++ * @pwm: pwm_device attached to the mikrobus port PWM pin.
++ * @pinctrl_selected: current pinctrl_selected state.
++ * @chip_select: chip select number mapped to the SPI
++ * CS pin on the mikrobus port and the RST pin on the mikrobus
++ * port
++ * @id: port id starting from 1
++ */
++struct mikrobus_port {
++	struct addon_board_info *board;
++	struct nvmem_device *eeprom;
++	struct i2c_adapter *i2c_adap;
++	struct spi_master *spi_mstr;
++	struct w1_master *w1_master;
++	struct platform_device *w1_gpio;
++	struct serdev_controller *ser_ctrl;
++	struct gpio_descs *gpios;
++	struct pwm_device *pwm;
++	struct pinctrl *pinctrl;
++	struct module *owner;
++	struct device dev;
++	char name[MIKROBUS_NAME_SIZE];
++	char *pinctrl_selected[MIKROBUS_NUM_PINCTRL_STATE];
++	unsigned int chip_select[MIKROBUS_NUM_CS];
++	int skip_scan;
++	int disable_eeprom;
++	int id;
++};
++#define to_mikrobus_port(d) container_of(d, struct mikrobus_port, dev)
++
++void mikrobus_board_unregister(struct mikrobus_port *port,
++				struct addon_board_info *board);
++int mikrobus_board_register(struct mikrobus_port *port,
++				struct addon_board_info *board);
++
++int mikrobus_port_gb_register(struct gbphy_host *host, void *manifest_blob, size_t manifest_size);
++int mikrobus_port_register(struct mikrobus_port *port);
++int mikrobus_port_pinctrl_select(struct mikrobus_port *port);
++void mikrobus_port_delete(struct mikrobus_port *port);
++int mikrobus_port_scan_eeprom(struct mikrobus_port *port);
++struct mikrobus_port *mikrobus_find_port_by_w1_master(struct w1_master *master);
++#endif /* __MIKROBUS_H */
+-- 
+2.30.0
+


### PR DESCRIPTION
split rename patch to delete and add.

Fixes https://github.com/jadonk/beagleconnect/issues/49

Temporarily we need to move gbphy.h and mikrobus.h to include/ since 
gbphy.c in drivers/staging/greybus/ needs to include mikrobus.h for instantiating
a mikroBUS port from a gbphy device and mikrobus_core.c needs to include
gbphy.h for getting the controllers(struct spi_master *, struct i2c_adapter *) from 
the gbphy devices, this can otherwise solved by moving mikrobus to drivers/staging/greybus/
or ```#include "../staging/greybus/gbphy.h```
