### PR TITLE
SW: update README and firmware-build.sh for mikroBUS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "sw/zephyrproject/greybus-for-zephyr"]
 	path = sw/zephyrproject/greybus-for-zephyr
 	url = https://github.com/jadonk/greybus-for-zephyr
+[submodule "sw/zephyrproject/greybus-for-zephyr-mikrobus"]
+	path = sw/zephyrproject/greybus-for-zephyr-mikrobus
+	url = https://github.com/vaishnav98/greybus-for-zephyr

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1436,3 +1436,160 @@ cd ~/beagleconnect/sw/buildroot
 /opt/gbridge.sh
 ----
 
+[[demo-3]]
+== mikroBUS over Greybus demo (Launchpad/SensorTag).
+
+Currently only a limited number of Add-on Board have been tested to work over Greybus. Simple Add-on boards without Interrupt Requirement are the ones that work currently. _BeagleConnect™ Freedom_ Gateway Setup instructions are same as before.
+
+=== Setup
+
+1. Clone or update source
++
+NOTE: If you have already cloned the source, skip this part and go to the second part of this step.
++
+[source,bash]
+----
+cd ~
+git clone --recurse-submodules --branch demo https://github.com/jadonk/beagleconnect
+----
++
+NOTE: If you just cloned the source, you don't need to perform this update.
++
+[source,bash]
+----
+cd ~
+git pull --recurse-submodules
+----
++
+2. CC1352 Zephyr toolchain
++
+[source,bash]
+----
+sudo apt install -y --no-install-recommends git cmake ninja-build gperf \
+  ccache dfu-util device-tree-compiler wget \
+  python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+  make gcc gcc-multilib g++-multilib libsdl2-dev \
+  cmake
+pip3 install --user -U west
+wget "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.4/zephyr-sdk-0.11.4-setup.run"
+chmod +x zephyr-sdk-0.11.4-setup.run
+./zephyr-sdk-0.11.4-setup.run -- -d ~/zephyr-sdk-0.11.4
+export PATH=~/.local/bin:"$PATH"
+export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_SDK_INSTALL_DIR=~/zephyr-sdk-0.11.4
+export USE_CCACHE=1
+cd ~/beagleconnect/sw/zephyrproject/zephyr
+west update
+west zephyr-export
+pip3 install --user -r scripts/requirements.txt
+----
++
+3. Linux gateway via buildroot
++
+[source,bash]
+----
+cd
+wget "https://buildroot.org/downloads/buildroot-2020.08.tar.gz"
+tar xzf buildroot-2020.08.tar.gz
+cd ~/beagleconnect/sw/buildroot
+make -C ~/buildroot-2020.08 O=$PWD BR2_EXTERNAL=$PWD beagleconnect_gateway_qemu_x86_64_defconfig
+----
+
+=== Building
+
+1.CC1352 Firmware
++
+[source,bash]
+----
+cd ~/beagleconnect/sw
+./build-firmware.sh
+----
++
+2. Buildroot
++
+[source,bash]
+----
+cd ~/beagleconnect/sw/buildroot
+make
+----
+
+=== Flashing
+
+==== Node
+
+1. Connect _CC1352R1 Launchpad_ via USB.
++
+2. Flash _CC1352R1 Launchpad_ using `west`.
++
+[source,bash]
+----
+cd ~/beagleconnect/sw/zephyrproject/zephyr
+west flash -d build/greybus_mikrobus_sensortag_2G
+----
+
+=== Run
+
+1. Disconnect and reconnect _BeagleConnect™ Freedom_.
++
+2. Start emulator.
++
+[source,bash]
+----
+cd ~/beagleconnect/sw/buildroot
+./run
+----
++
+4. Login using username `root` and password `tempppwd`.
+5. Start gbridge.
++
+[source,bash]
+----
+/opt/gbridge.sh > /dev/null 2>&1 &
+----
+/var/log/gbridge will have the gbridge log, and if the mikroBUS port has been instantiated successfully the kernel log will show the devices probe messages (by default the example is for Air Quality 2 Click and Weather Click):
+```
+greybus 1-2.2: GMP VID=0x00000126, PID=0x00000126
+greybus 1-2.2: DDBL1 Manufacturer=0x00000126, Product=0x00000126
+greybus 1-2.2: excess descriptors in interface manifest
+mikrobus:mikrobus_port_gb_register: mikrobus gb_probe , num cports= 3, manifest_size 252
+mikrobus:mikrobus_port_gb_register: protocol added 11
+mikrobus:mikrobus_port_gb_register: protocol added 3
+mikrobus:mikrobus_port_gb_register: protocol added 2
+mikrobus:mikrobus_port_register: registering port mikrobus-0
+mikrobus_manifest:mikrobus_manifest_attach_device: parsed device 1, driver=bme280, protocol=3, reg=76
+mikrobus_manifest:mikrobus_manifest_attach_device: parsed device 2, driver=ams-iaq-core, protocol=3, reg=5a
+mikrobus_manifest:mikrobus_manifest_parse:  Greybus Service Sample Application manifest parsed with 2 devices
+mikrobus mikrobus-0: registering device : bme280
+mikrobus mikrobus-0: registering device : ams-iaq-core
+```
+==== Trying for different Clicks
+
+Currently the Click Manifests are selected at compile time(temporarily until Click ID driver is implemented in Zephyr) and the Clicks can be choosen by updating the Kconfig options https://github.com/vaishnav98/greybus-for-zephyr/blob/9f937760960a8303179bff6b9c6fefc9d9622d38/samples/subsys/greybus/net/boards/cc1352r1_launchxl.conf#L14[here] :
+```
+CONFIG_GREYBUS_CLICK_MANIFEST_BUILTIN=y
+CONFIG_GREYBUS_MIKROBUS_CLICK1_NAME="WEATHER-CLICK"
+CONFIG_GREYBUS_MIKROBUS_CLICK2_NAME="AIR-QUALITY-2-CLICK"
+```
+The names of the add-on boards should be specified same as that present in the https://github.com/vaishnav98/manifesto/tree/6b68006f6c62f3d680b947d4a91068be9ff22218/manifests[manifesto/manifests] repository.
+
+==== Describing On-board devices through Zephyr DT
+For MCU Clients like the SensorTag, the on-board fixed devices(like the OPT3001) can be described over the https://github.com/vaishnav98/greybus-for-zephyr/blob/9f937760960a8303179bff6b9c6fefc9d9622d38/samples/subsys/greybus/net/boards/cc1352r_sensortag.overlay#L180[Zephyr Device Tree Overlay] in this manner :
+```
+gbstring3 {
+			label = "GBSTRING_3";
+			status = "okay";
+			compatible = "zephyr,greybus-string";
+			id = <3>;
+			greybus-string = "opt3001";
+	};
+
+gbdevice0 {
+		label = "GBDEVICE_0";
+		status = "okay";
+		compatible = "zephyr,greybus-device";
+		id = <1>;
+		driver-string-id = <&gbstring3>;
+		protocol = <3>;
+		addr = <0x44>;
+	};
+```

--- a/sw/build-firmware.sh
+++ b/sw/build-firmware.sh
@@ -5,7 +5,7 @@ export ZEPHYR_TOOLCHAIN_VARIANT=${ZEPHYR_TOOLCHAIN_VARIANT:-zephyr}
 export ZEPHYR_SDK_INSTALL_DIR=${ZEPHYR_SDK_INSTALL_DIR:-~/zephyr-sdk-0.11.4}
 export ZEPHYR_BASE=${ZEPHYR_BASE:-$SWDIR/zephyrproject/zephyr}
 export ZPRJ=$SWDIR/zephyrproject
-export ZEPHYR_EXTRA_MODULES=${ZEPHYR_EXTRA_MODULES:-$ZPRJ/greybus-for-zephyr}
+export ZEPHYR_EXTRA_MODULES=${ZEPHYR_EXTRA_MODULES:-$ZPRJ/greybus-for-zephyr-mikrobus}
 
 # MSP430
 cd $SWDIR/usb_uart_bridge
@@ -15,6 +15,10 @@ make
 cd $ZEPHYR_BASE
 
 ## 802.15.4 SubG
+west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
+
+west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
+
 west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
 
 west build -p always -b beagleconnect_freedom $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y -DBOARD_ROOT=$ZPRJ/wpanusb_bc
@@ -26,6 +30,10 @@ west build -p always -b cc1352r1_launchxl $ZPRJ/sensortest -d $ZEPHYR_BASE/build
 west build -p always -b beagleconnect_freedom $ZPRJ/sensortest -d $ZEPHYR_BASE/build/sensortest_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc
 
 ## 802.15.4 2.4GHz
+
+west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag_2G -- -DOVERLAY_CONFIG=overlay-802154.conf -DCONFIG_IEEE802154_CC13XX_CC26XX=y
+
+west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_launchpad_2G -- -DOVERLAY_CONFIG=overlay-802154.conf -DCONFIG_IEEE802154_CC13XX_CC26XX=y
 
 west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_launchpad_2G -- -DCONFIG_IEEE802154_CC13XX_CC26XX=y
 

--- a/sw/linux/README.md
+++ b/sw/linux/README.md
@@ -6,8 +6,7 @@ To build, make sure you've already built your previous kernel properly, then...
 
 ```
 cd <your linux source tree>
-git am <beagleconnect source tree>/sw/linux/v2-0001-RFC-mikroBUS-driver-for-add-on-boards.patch
-git am <beagleconnect source tree>/sw/linux/0001-mikroBUS-build-fixes.patch
+git am <beagleconnect source tree>/sw/linux/*.patch
 scripts/kconfig/merge_config.sh <beagleconnect source tree>/sw/linux/mikrobus.config
 make
 sudo make modules_install
@@ -19,9 +18,13 @@ Then reboot and profit!
 Notes:
 * You'll need at least a 5.8 kernel
 
-## Install
+## Instantiation
 
-You'll still need something to instantiate a mikroBUS socket on your system.
+mikroBUS ports on a system can be of two different types:
+* physical mikroBUS ports on host : For host systems like a [PocketBeagle](https://github.com/beagleboard/pocketbeagle/wiki/System-Reference-Manual#72-mikrobus-socket-connections) or a BeagleBone Black Attached to [mikroBUS Cape](mikroe.com/beaglebone-mikrobus-cape), the mikroBUS ports are physically present on the board and they can be instantiated over a suitable device tree overlay[1] to describe the mikroBUS port, with physical mikroBUS ports the Click Board discovery is performed directly by reading the manifest from the Click ID Board[2] physically over 1-wire.
+* mikroBUS ports instantiated over Greybus : mikroBUS ports are instantiated over Greybus and in this case the Click Board discovery is performed along with the Greybus Interface discovery mechanism over the Greybus manifest, in this case the remote MCU device will either store the Add-on Board Manifests during compile time or fetch it during runtime from Click ID Board(TODO) and pass it to the host along with the Greybus Interface Manifest.
 
-TBD
 
+
+1. [PocketBeagle mikroBUS Port 0 Device Tree Overlay](https://github.com/beagleboard/bb.org-overlays/blob/master/src/arm/PB-MIKROBUS-0.dts)
+2. [mikroBUS Click ID Adapter Hardware draft documentation](https://download.mikroe.com/documents/mikrobu_socket/ClickIdentificationFunctionlity.pdf)


### PR DESCRIPTION
* Added mikroBUS over Greybus Submodule
* Updated README for mikroBUS over Greybus instructions and updated FW build script for building examples for SensorTag and CC1352R Launcpad, and also instructions for trying different clicks and describing devices over Zephyr DT


https://github.com/jadonk/beagleconnect/issues/48
https://github.com/jadonk/beagleconnect/issues/19