### PR TITLE
sw: update firmware build script

### DIFF
--- a/sw/build-firmware.sh
+++ b/sw/build-firmware.sh
@@ -15,25 +15,29 @@ make
 cd $ZEPHYR_BASE
 
 ## 802.15.4 SubG
-west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
+west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag -- -DOVERLAY_CONFIG=overlay-802154-subg.conf
 
-west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
+west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf
+
+west build -p always -b beagleconnect_freedom $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_beagleconnect -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_RADIO_TX_POWER=20 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DIV_SETUP_PA=1 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_CS_THRESHOLD=-20 -DBOARD_ROOT=$ZPRJ/wpanusb_bc
 
 west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_launchpad -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y
 
 west build -p always -b beagleconnect_freedom $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_beagleconnect -- -DOVERLAY_CONFIG=overlay-802154-subg.conf -DCONFIG_NET_CONFIG_IEEE802154_DEV_NAME=\"IEEE802154_1\" -DCONFIG_IEEE802154_CC13XX_CC26XX=n -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ=y -DBOARD_ROOT=$ZPRJ/wpanusb_bc
 
-west build -p always -b beagleconnect_freedom $ZPRJ/wpanusb_bc -d $ZEPHYR_BASE/build/wpanusb_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc
+west build -p always -b beagleconnect_freedom $ZPRJ/wpanusb_bc -d $ZEPHYR_BASE/build/wpanusb_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc -DCONFIG_NET_CONFIG_IEEE802154_RADIO_TX_POWER=20 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DIV_SETUP_PA=1 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_CS_THRESHOLD=-20
 
 west build -p always -b cc1352r1_launchxl $ZPRJ/sensortest -d $ZEPHYR_BASE/build/sensortest_launchpad -- -DOVERLAY_CONFIG=overlay-subghz.conf
 
-west build -p always -b beagleconnect_freedom $ZPRJ/sensortest -d $ZEPHYR_BASE/build/sensortest_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc
+west build -p always -b beagleconnect_freedom $ZPRJ/sensortest -d $ZEPHYR_BASE/build/sensortest_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc -DCONFIG_NET_CONFIG_IEEE802154_RADIO_TX_POWER=20 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DIV_SETUP_PA=1 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_CS_THRESHOLD=-20
 
 ## 802.15.4 2.4GHz
 
-west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag_2G -- -DOVERLAY_CONFIG=overlay-802154.conf -DCONFIG_IEEE802154_CC13XX_CC26XX=y
+west build -p always -b cc1352r_sensortag $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_sensortag_2G -- -DOVERLAY_CONFIG=overlay-802154.conf
 
-west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_launchpad_2G -- -DOVERLAY_CONFIG=overlay-802154.conf -DCONFIG_IEEE802154_CC13XX_CC26XX=y
+west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_launchpad_2G -- -DOVERLAY_CONFIG=overlay-802154.conf
+
+west build -p always -b beagleconnect_freedom $ZPRJ/greybus-for-zephyr-mikrobus/samples/subsys/greybus/net -d build/greybus_mikrobus_beagleconnect_2G -- -DOVERLAY_CONFIG=overlay-802154.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc
 
 west build -p always -b cc1352r1_launchxl $ZPRJ/greybus-for-zephyr/samples/subsys/greybus/net -d build/greybus_launchpad_2G -- -DCONFIG_IEEE802154_CC13XX_CC26XX=y
 


### PR DESCRIPTION
* update build script with config to turn on PA
* update mikrobus-greybus submodule with beagleconnect freedom config

**sensortest** :
```

vaishnav@spectre:~/freedom/beagleconnect/sw$ ./test-net.sh
ping6 -I lowpan0 ff02::1 -c 5
+ ping6 -I lowpan0 ff02::1 -c 5
ping6: Warning: source address might be selected on device other than: lowpan0
PING ff02::1(ff02::1) from :: lowpan0: 56 data bytes
64 bytes from fe80::1eee:b121:4b:1200%lowpan0: icmp_seq=1 ttl=64 time=53.8 ms
64 bytes from fe80::1eee:b121:4b:1200%lowpan0: icmp_seq=2 ttl=64 time=30.0 ms
64 bytes from fe80::1eee:b121:4b:1200%lowpan0: icmp_seq=3 ttl=64 time=30.1 ms
64 bytes from fe80::1eee:b121:4b:1200%lowpan0: icmp_seq=4 ttl=64 time=29.9 ms
64 bytes from fe80::1eee:b121:4b:1200%lowpan0: icmp_seq=5 ttl=64 time=30.0 ms

--- ff02::1 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4004ms
rtt min/avg/max/mdev = 29.920/34.745/53.792/9.523 ms
vaishnav@spectre:~/freedom/beagleconnect/sw$ python3 ./sensortest-rx.py
('fe80::1eee:b121:4b:1200', 49475, 0, 8)  b'3l: 29.780000;4x:-7.660800;4y:-1.225728;4z:-5.362560;5h: 54.255676;5t: 26.107254'
('fe80::1eee:b121:4b:1200', 49475, 0, 8)  b'3l: 29.570000;4x:-7.507584;4y:-1.378944;4z:-5.209344;5h: 54.199218;5t: 26.180267'
^CTraceback (most recent call last):
  File "./sensortest-rx.py", line 15, in <module>
    data, sender = sock.recvfrom(1024)
KeyboardInterrupt

```