### PR TITLE
sw: buildroot: start gbridge as service at startup

### DIFF
--- a/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/init.d/S99gbridge
+++ b/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/init.d/S99gbridge
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. /etc/sysconfig/functions
+
+if [[ $(lsusb | grep -c "2047:0aa5") -eq "0" ]]; 
+then
+  boot_mesg -n "BeagleConnect Freedom wpanusb device not found"
+  exit 1
+fi
+
+/opt/gbridge.sh &

--- a/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/network/interfaces
+++ b/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/network/interfaces
@@ -6,16 +6,3 @@ iface eth0 inet dhcp
   pre-up /etc/network/nfs_check
   wait-delay 15
   hostname $(hostname)
-
-allow-hotplug wpan0
-auto wpan0
-iface wpan0 inet6 manual
-  down ip link set lowpan0 down
-  down ip link set wpan0 down
-  pre-up ip link set wpan0 down
-  pre-up iwpan dev wpan0 set pan_id 0xabcd
-  pre-up iwpan phy `iwpan phy | grep -m1 wpan_phy | cut -d' ' -f2` set channel 0 1
-  pre-up ip link add link wpan0 name lowpan0 type lowpan
-  pre-up ip link set lowpan0 up
-  pre-up ip -6 addr add 2001:db8::2/64 dev lowpan0
-  up ip link set wpan0 up

--- a/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/sysconfig/modules
+++ b/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/etc/sysconfig/modules
@@ -14,3 +14,8 @@ gb-spilib
 gb-uart
 hm3301
 wpanusb
+bmp280_i2c
+st_accel_i2c
+rtc_ds1307
+opt3001
+ams-iaq-core

--- a/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/opt/gbridge.sh
+++ b/sw/buildroot/board/beagleboard/beagleconnect_gateway_qemu_x86_64/rootfs_overlay/opt/gbridge.sh
@@ -1,7 +1,18 @@
-#!/bin/sh -xv
+#!/bin/sh
+
+IFLP=`ifconfig | grep lowpan`
+IEEE_802154_CHANNEL=26
+if [[ $(iwpan phy | grep -c "906 MHz") -ne "0" ]]; 
+then
+  IEEE_802154_CHANNEL=1
+  echo "setting up wpanusb gateway for IEEE 802154 CHANNEL 1(906 Mhz)"
+else
+  echo "setting up wpanusb gateway for IEEE 802154 CHANNEL 26"
+fi
+
 IFLP=`ifconfig | grep lowpan`
 ip link set wpan0 down
-iwpan phy phy0 set channel 0 26
+iwpan phy phy0 set channel 0 $IEEE_802154_CHANNEL
 iwpan dev wpan0 set pan_id 0xabcd
 if [ "$IFLP" == "" ]; then
   ip link add link wpan0 name lowpan0 type lowpan
@@ -20,4 +31,4 @@ sleep 1
 gbridge > /var/log/gbridge &
 
 sleep 5
-while true; do gpioset 0 6=1; gpioset 0 6=0; sleep 1; done &
+while true; do gpioset 0 18=1; gpioset 0 18=0; sleep 1; done &


### PR DESCRIPTION
* disable /etc/network/interfaces
* start gbridge as service at startup
* load required modules for the on-board sensors