### PR TITLE
sw: mikrobus: add mikrobus click ID flasher as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "sw/zephyrproject/greybus-for-zephyr-mikrobus"]
 	path = sw/zephyrproject/greybus-for-zephyr-mikrobus
 	url = https://github.com/jadonk/greybus-for-zephyr
+[submodule "sw/zephyrproject/mikrobus-clickid-flasher"]
+	path = sw/zephyrproject/mikrobus-clickid-flasher
+	url = https://github.com/vaishnav98/mikrobus-clickid-flasher.git

--- a/sw/flash-clickid.sh
+++ b/sw/flash-clickid.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+
+export SWDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+export MSP430_TOOLCHAIN_PATH=${MSP430_TOOLCHAIN_PATH:-/opt/msp430-gcc}
+export ZEPHYR_TOOLCHAIN_VARIANT=${ZEPHYR_TOOLCHAIN_VARIANT:-zephyr}
+export ZEPHYR_SDK_INSTALL_DIR=${ZEPHYR_SDK_INSTALL_DIR:-~/zephyr-sdk-0.11.4}
+export ZEPHYR_BASE=${ZEPHYR_BASE:-$SWDIR/zephyrproject/zephyr}
+export ZPRJ=$SWDIR/zephyrproject
+export ZEPHYR_EXTRA_MODULES=${ZEPHYR_EXTRA_MODULES:-"$ZPRJ/mikrobus-clickid-flasher"}
+
+west build -p always -t flash -b beagleconnect_freedom $ZPRJ/mikrobus-clickid-flasher/samples/subsys/mikrobus/flasher -d build/greybus_mikrobus_beagleconnect_flasher -- -DBOARD_ROOT=$ZPRJ/wpanusb_bc -DCONFIG_MIKROBUS_FLASHER_CLICK_NAME='"'$1'"'


### PR DESCRIPTION
This project allows to flash the eeprom on the new mikrobus click ID adapter from BeagleConnect Freedom,
 
The scheme for writing manifests is as follows:

1.  write production manifest(fixed, minimum information for enabling through userspace if driver is available) at addr 0x0000 onwards
2. write variable manifest at next free block after writing production manifest 
3. update eeprom bytes with production manifest start block 
4. write protect fixed/production manifest(currently commented)

**production/fixed manifest :**

 manifest available at click production time(contains some mikroe specific strings also),
 if driver does not exist at production time,it will contain minimal information on click
 hardware to enable for development through userspace, if driver
 exists additonal greybus/mikrobus information will be present

**variable manifest :** 

- updated in case a newer version of linux updates the format for receiving DT parameter/named gpios .etc

- updated in case driver is available for 1 or more devices on board after click production