### PR TITLE
SW: Update greybus mikrobus and FW build workflow

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -107,10 +107,9 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: zephyr
+          name: bcf-firmware-bin
           path: |
-            sw/zephyrproject/zephyr/build
-            sw/cc2538-bsl.py
+            sw/bcf-zephyr-fw/*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -117,3 +117,18 @@ jobs:
           path: |
             sw/usb_uart_bridge/usb_uart_bridge*.*
 
+      - name: Prepare Release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cd sw/
+          mkdir -p bcf-firmware-release
+          cp bcf-zephyr-fw/* bcf-firmware-release/
+          cp usb_uart_bridge/usb_uart_bridge*.* bcf-firmware-release/
+          zip -r bcf-firmware-release.zip bcf-firmware-release
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            sw/bcf-firmware-release.zip

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,7 @@
 	url = https://github.com/jadonk/greybus-for-zephyr
 [submodule "sw/zephyrproject/greybus-for-zephyr-mikrobus"]
 	path = sw/zephyrproject/greybus-for-zephyr-mikrobus
-	url = https://github.com/jadonk/greybus-for-zephyr
+	url = https://github.com/vaishnav98/greybus-for-zephyr
 [submodule "sw/zephyrproject/mikrobus-clickid-flasher"]
 	path = sw/zephyrproject/mikrobus-clickid-flasher
 	url = https://github.com/vaishnav98/mikrobus-clickid-flasher.git

--- a/sw/build-firmware.sh
+++ b/sw/build-firmware.sh
@@ -21,4 +21,18 @@ west build -p always -b beagleconnect_freedom $ZPRJ/greybus-for-zephyr-mikrobus/
 # WPANUSB Gateway SubG
 west build -p always -b beagleconnect_freedom $ZPRJ/wpanusb_bc -d $ZEPHYR_BASE/build/wpanusb_beagleconnect -- -DOVERLAY_CONFIG=overlay-subghz.conf -DBOARD_ROOT=$ZPRJ/wpanusb_bc -DCONFIG_NET_CONFIG_IEEE802154_RADIO_TX_POWER=14 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_DIV_SETUP_PA=1 -DCONFIG_IEEE802154_CC13XX_CC26XX_SUB_GHZ_CS_THRESHOLD=-20
 
+# make a FW release directory with the FW binaries and relevant debug info
+mkdir -p $SWDIR/bcf-zephyr-fw
+cp $SWDIR/cc2538-bsl.py  $SWDIR/bcf-zephyr-fw/
 
+copy_fwbin () {
+		if [ -f $ZEPHYR_BASE/build/$1/zephyr/zephyr.bin ] ; then
+			cp $ZEPHYR_BASE/build/$1/zephyr/zephyr.bin $SWDIR/bcf-zephyr-fw/$1.bin
+			cp $ZEPHYR_BASE//build/$1/zephyr/zephyr.dts $SWDIR/bcf-zephyr-fw/$1.dts
+			cp $ZEPHYR_BASE/build/$1/zephyr/.config $SWDIR/bcf-zephyr-fw/$1.config
+		fi
+}
+
+copy_fwbin sensortest_beagleconnect
+copy_fwbin greybus_mikrobus_beagleconnect
+copy_fwbin wpanusb_beagleconnect

--- a/sw/cc2538-bsl.py
+++ b/sw/cc2538-bsl.py
@@ -1120,7 +1120,9 @@ if __name__ == "__main__":
     # print("RUN CC2535-BSL!")
     # print(sys.argv[1:])
     port = None
-    file = sys.argv[1] + '/zephyr/zephyr.bin'
+    file = sys.argv[1]
+    if not sys.argv[1].endswith(".bin"):
+        file += '/zephyr/zephyr.bin'
     if len(sys.argv) > 2:
         port = sys.argv[2]
     main(file, port)


### PR DESCRIPTION
Hi @jadonk ,

Can you review this PR, the main changes are updating the greybus-for-zephyr-mikrobus submodule, the previous version was not the latest one which caused the mikrobus sample to fail before. 
Once https://github.com/jadonk/greybus-for-zephyr/pull/3 is merged, greybus-for-zephyr-mikrobus submodule can be updated back to https://github.com/jadonk/greybus-for-zephyr
* updated the FW build workflow to upload only the necessary binaries/debug info(DTS, Kconfig) instead of uploading the entire build/ directory and also to make a FW release with these binaries for a tag.
* FW Release for testing: https://github.com/vaishnav98/beagleconnect/releases/tag/bcf-beta0.0.3
* minor update to cc2538-bsl.py so that uploading .bin file directly instead of being present in a folder, so that the below usage also works:

```
vaishnav@spectre:~/Downloads/bcf-firmware-release$ ./cc2538-bsl.py wpanusb_beagleconnect.bin 
Opening port /dev/ttyACM0, baud 50000
Reading data from wpanusb_beagleconnect.bin
Firmware file: Raw Binary
  ...
Verified (match: 0xc9f1e101)
```