### PR TITLE
sw: enable greybus app in FW release directory

### DIFF
--- a/sw/build-firmware.sh
+++ b/sw/build-firmware.sh
@@ -43,4 +43,5 @@ copy_fwbin () {
 
 copy_fwbin wpanusb_beagleconnect
 copy_fwbin sensortest_beagleconnect
-#copy_fwbin greybus_mikrobus_beagleconnect
+copy_fwbin greybus_mikrobus_beagleconnect
+copy_fwbin bcfserial_beagleconnect


### PR DESCRIPTION
Hi @jadonk ,
Tested the greybus-mikrobus application with BCF Rev C5, this PR needs to be merged for the on-board sensors to work properly as they are behind the analog switch. https://github.com/jadonk/greybus-for-zephyr/pull/4 and also greybus-for-zephyr-mikrobus submodule need to be updated

Logs for testing has  been added here: https://github.com/jadonk/greybus-for-zephyr/pull/4#issuecomment-991946977